### PR TITLE
Split the tests into seperate executables

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,39 +1,33 @@
+function(fgt_test target)
+    add_executable(${target} ${ARGN})
+    configure_target(${target})
+    target_include_directories(${target}
+        PRIVATE
+            ${PROJECT_SOURCE_DIR}/include
+            ${PROJECT_SOURCE_DIR}/src
+            ${CMAKE_CURRENT_BINARY_DIR}
+            ${gtest_SOURCE_DIR}/include
+        )
+    target_link_libraries(${target}
+        PRIVATE
+            gtest_main
+            Library-C++
+        )
+    add_test(NAME ${target} COMMAND ${target})
+endfunction()
+
 configure_file(
     config.hpp.in
     ${CMAKE_CURRENT_BINARY_DIR}/config.hpp
     )
 
-set(src
-    clustering_test.cpp
-    constant_series_test.cpp
-    direct_test.cpp
-    direct_tree_test.cpp
-    fgt_test.cpp
-    gauss_transform_test.cpp
-    ifgt_test.cpp
-    monomials_test.cpp
-    truncation_number_test.cpp
-    )
-
-add_executable(Test ${src})
-configure_target(Test)
-set_target_properties(Test PROPERTIES OUTPUT_NAME fgt-test)
-target_include_directories(Test
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${PROJECT_SOURCE_DIR}/src
-        ${CMAKE_CURRENT_BINARY_DIR}
-        ${gtest_SOURCE_DIR}/include
-    )
-target_link_libraries(Test PRIVATE Library-C++ gtest_main)
-add_test(NAME unit-tests COMMAND Test)
-
-add_executable(Trial trial.cpp)
-configure_target(Trial)
-set_target_properties(Trial PROPERTIES OUTPUT_NAME fgt-trial)
-target_include_directories(Trial
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${gtest_SOURCE_DIR}/include
-    )
-target_link_libraries(Trial PRIVATE Library-C++ gtest_main)
+fgt_test(clustering clustering_test.cpp)
+fgt_test(constant-series constant_series_test.cpp)
+fgt_test(direct direct_test.cpp)
+fgt_test(direct-tree direct_tree_test.cpp)
+fgt_test(fgt fgt_test.cpp)
+fgt_test(gauss-transform gauss_transform_test.cpp)
+fgt_test(ifgt ifgt_test.cpp)
+fgt_test(monomials monomials_test.cpp)
+fgt_test(trial trial.cpp)
+fgt_test(truncation-number truncation_number_test.cpp)


### PR DESCRIPTION
This makes tracking through ctest a bit prettier. Also, we added trial into the tests since it doesn't take that long.