### PR TITLE
Add class-based interface to each fgt method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(Library-C++
     src/direct_tree.cpp
     src/ifgt.cpp
     src/openmp.cpp
+    src/transform.cpp
     ${cluster_src}
     ${PROJECT_BINARY_DIR}/version.cpp
     )

--- a/README.md
+++ b/README.md
@@ -35,6 +35,22 @@ The library provides a few different ways to calculate the Gauss transform:
 - `fgt::ifgt` uses the [Improved Fast Gauss Transform (pdf)](http://www.umiacs.umd.edu/~yangcj/papers/siam_fgt_v11.pdf) to speed up the calculation.
   IFGT is fast for large bandwidths but can break down for smaller bandwidths.
 
+There's also a class-based interface:
+
+```cpp
+#include <fgt.hpp>
+
+void my_great_function(const double* x, size_t x_rows,
+                       const double* y, size_t y_rows,
+                       size_t cols) {
+    double bandwidth = 0.3;
+    fgt::Direct direct(x, x_rows, cols, bandwidth);
+    std::vector<double> result = direct.compute(y, y_rows);
+}
+```
+
+This lets you break up your transform into a pre-compute and a compute step, which can save you some cycles if you're re-using the same source dataset in a more advanced transform (e.g. direct_tree or ifgt).
+
 There is some benchmarking code available in the [bench](bench/) directory, which you can use to try to get a sense of the performance of the various modes.
 We found a crossover point at bandwidths of a bit more than 0.2 during local testing on a Mac laptop; YMMV.
 

--- a/include/fgt.hpp
+++ b/include/fgt.hpp
@@ -24,6 +24,7 @@
 #pragma once
 
 #include <cstddef>
+#include <memory>
 #include <vector>
 
 /// Top-level namespace for all things fgt.

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -22,19 +22,16 @@
 
 namespace fgt {
 
-std::vector<double> direct(const double* source, size_t rows_source,
-                           const double* target, size_t rows_target,
-                           size_t cols, double bandwidth) {
-    std::vector<double> weights(rows_source, 1.0);
-    return direct(source, rows_source, target, rows_target, cols, bandwidth,
-                  weights.data());
-}
+Direct::Direct(const double* source, size_t rows, size_t cols, double bandwidth)
+    : Transform(source, rows, cols, bandwidth) {}
 
-std::vector<double> direct(const double* source, size_t rows_source,
-                           const double* target, size_t rows_target,
-                           size_t cols, double bandwidth,
-                           const double* weights) {
-    double h2 = bandwidth * bandwidth;
+std::vector<double> Direct::compute_impl(const double* target,
+                                         size_t rows_target,
+                                         const double* weights) const {
+    double h2 = bandwidth() * bandwidth();
+    const double* source = this->source();
+    size_t rows_source = this->rows_source();
+    size_t cols = this->cols();
     std::vector<double> g(rows_target, 0.0);
 #pragma omp parallel for
     for (size_t j = 0; j < rows_target; ++j) {
@@ -48,5 +45,20 @@ std::vector<double> direct(const double* source, size_t rows_source,
         }
     }
     return g;
+}
+
+std::vector<double> direct(const double* source, size_t rows_source,
+                           const double* target, size_t rows_target,
+                           size_t cols, double bandwidth) {
+    return Direct(source, rows_source, cols, bandwidth)
+        .compute(target, rows_target);
+}
+
+std::vector<double> direct(const double* source, size_t rows_source,
+                           const double* target, size_t rows_target,
+                           size_t cols, double bandwidth,
+                           const double* weights) {
+    return Direct(source, rows_source, cols, bandwidth)
+        .compute(target, rows_target, weights);
 }
 }

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -15,29 +15,24 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
 
-#include <cstddef>
-
 #include "fgt.hpp"
 
 namespace fgt {
 
-/// Tuning parameters for the IFGT.
-///
-/// In general, you shouldn't need to create these yourself.
-struct IfgtParameters {
-    /// The number of clusters that should be used for the IFGT.
-    size_t nclusters;
-    /// The cutoff radius.
-    double cutoff_radius;
-};
+Transform::Transform(const double* source, size_t rows, size_t cols,
+                     double bandwidth)
+    : m_source(source),
+      m_rows_source(rows),
+      m_cols(cols),
+      m_bandwidth(bandwidth) {}
 
-/// Chooses appropriate parameters for an IFGT.
-IfgtParameters ifgt_choose_parameters(size_t cols, double bandwidth,
-                                      double epsilon, size_t max_num_clusters,
-                                      size_t truncation_number_ul);
-/// Chooses the appropriate truncation number for IFGT, given a max clustering
-/// radius.
-size_t ifgt_choose_truncation_number(size_t cols, double bandwidth,
-                                     double epsilon, double max_radius,
-                                     size_t truncation_number_ul);
+std::vector<double> Transform::compute(const double* target, size_t rows) {
+    std::vector<double> weights(this->rows_source(), 1.0);
+    return compute(target, rows, weights.data());
+}
+
+std::vector<double> Transform::compute(const double* target, size_t rows,
+                                       const double* weights) {
+    return compute_impl(target, rows, weights);
+}
 }

--- a/test/direct_test.cpp
+++ b/test/direct_test.cpp
@@ -28,4 +28,15 @@ TEST(Direct, WithWeights) {
         ASSERT_DOUBLE_EQ(no_weights[i], with_weights[i]);
     }
 }
+
+TEST(Direct, ClassBased) {
+    auto source = load_ascii_test_matrix<double>("X.txt");
+    auto target = load_ascii_test_matrix<double>("Y.txt");
+    Direct direct(source.data.data(), source.rows, source.cols, 0.5);
+    auto actual = direct.compute(target.data.data(), target.rows);
+    auto expected = load_ascii_test_matrix<double>("direct.txt").data;
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_NEAR(expected[i], actual[i], 1e-4);
+    }
+}
 }

--- a/test/direct_tree_test.cpp
+++ b/test/direct_tree_test.cpp
@@ -31,4 +31,17 @@ TEST(DirectTree, WithWeights) {
         ASSERT_DOUBLE_EQ(no_weights[i], with_weights[i]);
     }
 }
+
+TEST(DirectTree, ClassBased) {
+    auto source = load_ascii_test_matrix<double>("X.txt");
+    auto target = load_ascii_test_matrix<double>("Y.txt");
+    auto expected = direct(source.data.data(), source.rows, target.data.data(),
+                           target.rows, source.cols, 0.5);
+    auto actual =
+        DirectTree(source.data.data(), source.rows, source.cols, 0.5, 1e-4)
+            .compute(target.data.data(), target.rows);
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_NEAR(expected[i], actual[i], 1e-4);
+    }
+}
 }

--- a/test/ifgt_test.cpp
+++ b/test/ifgt_test.cpp
@@ -18,10 +18,22 @@ TEST(Ifgt, Reference) {
     }
 }
 
+TEST(Ifgt, ClassBased) {
+    auto source = load_ascii_test_matrix<double>("X.txt");
+    auto target = load_ascii_test_matrix<double>("Y.txt");
+    auto expected = direct(source.data.data(), source.rows, target.data.data(),
+                           target.rows, source.cols, 0.5);
+    auto actual = Ifgt(source.data.data(), source.rows, source.cols, 0.5, 1e-4)
+                      .compute(target.data.data(), target.rows);
+    ASSERT_EQ(expected.size(), actual.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_NEAR(expected[i], actual[i], 1e-2);
+    }
+}
+
 TEST(Ifgt, ChooseParameters) {
     IfgtParameters params = ifgt_choose_parameters(2, 0.3, 1e-6, 189, 200);
     EXPECT_EQ(13, params.nclusters);
-    EXPECT_EQ(17, params.max_truncation_number);
     EXPECT_NEAR(1.1151, params.cutoff_radius, 1e-4);
 }
 


### PR DESCRIPTION
The class-based interface lets us split each transform into two steps —
a pre-compute step using just the source data, and the compute step
against the target data and weights. The more advanced fgt methods
(direct_tree, ifgt) use some data structures that are computed using
only the source data, so the pre-compute step can create those data
structure.

This is useful for applications that re-use the same source data with
changing targets and/or weights.