### PR TITLE
Turn off bench by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(src/version.cpp.in
     ${PROJECT_BINARY_DIR}/version.cpp
     )
 
-option(WITH_BENCH "Build benchmark executable" ON)
+option(WITH_BENCH "Build benchmark executable" OFF)
 option(WITH_OPENMP "Use OpenMP parallelization" OFF)
 option(WITH_TESTS "Build test suite" ON)
 message(STATUS "[fgt] With OpenMP: ${WITH_OPENMP}")

--- a/scripts/travis-script.sh
+++ b/scripts/travis-script.sh
@@ -8,6 +8,7 @@ home=$(pwd)
 mkdir build
 cd build
 cmake .. -DWITH_TESTS=ON \
+  -DWITH_BENCH=ON \
   -DWITH_OPENMP=${FGT_WITH_OPENMP} \
   -DBUILD_SHARED_LIBS=ON \
   -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Most people won't need it, so don't build it. However, build it on
Travis, to make sure it doesn't regress.