### PR TITLE
Remove minimum cutoff radius

### DIFF
--- a/src/ifgt.cpp
+++ b/src/ifgt.cpp
@@ -58,8 +58,7 @@ IfgtParameters ifgt_choose_parameters(size_t cols, double bandwidth,
                                       double epsilon, size_t max_num_clusters,
                                       size_t truncation_number_ul) {
     double h2 = bandwidth * bandwidth;
-    double radius = std::min(std::sqrt(cols),
-                             bandwidth * std::sqrt(std::log(1.0 / epsilon)));
+    double radius = bandwidth * std::sqrt(std::log(1.0 / epsilon));
     double complexity_min = std::numeric_limits<double>::max();
     size_t nclusters = 0;
 

--- a/test/ifgt_test.cpp
+++ b/test/ifgt_test.cpp
@@ -34,4 +34,14 @@ TEST(Ifgt, ChooseTruncationNumber) {
         ifgt_choose_truncation_number(2, 0.3, 1e-6, 0.1, 200);
     EXPECT_EQ(9, truncation_number);
 }
+
+TEST(Ifgt, HighBandwidth) {
+    auto source = load_ascii_test_matrix("X.txt");
+    auto target = load_ascii_test_matrix("Y.txt");
+    target = target.array() + 2;
+    auto expected = direct(source, target, 3.5);
+    auto actual = ifgt(source, target, 3.5, 1e-4);
+    ASSERT_EQ(expected.size(), actual.size());
+    EXPECT_TRUE(expected.isApprox(actual, 1e-2));
+}
 }


### PR DESCRIPTION
The minimum cutoff radius, based on dimensionality, was preventing a
high bandwith from really expanding the cutoff radius for the ifgt. This
high bandwidth is necessary in the case when the two point sets are not
centered on each other.