### PR TITLE
Issues/32 downgrade cmake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ addons:
       - g++-4.8
 
 install:
-  - scripts/travis-install-cmake.sh && export PATH=$(pwd)/cmake/bin:$PATH
+  - scripts/travis-install-cmake.sh && export PATH=$(pwd)/cmake-3.0.2/bin:$PATH
   - scripts/travis-install-eigen3.sh
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(fgt CXX C)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.0)
 
 message(STATUS "[fgt] Compiler: ${CMAKE_CXX_COMPILER_ID}")
 
@@ -53,13 +53,9 @@ target_include_directories(Library-C++
     include
     ${NANOFLANN_SOURCE_DIR}/include
     )
-target_compile_features(Library-C++
-    PUBLIC
-    cxx_generalized_initializers
-    cxx_right_angle_brackets
-    cxx_auto_type
-    )
 target_compile_options(Library-C++
+    PUBLIC
+    -std=c++11
     PRIVATE
     -Wall
     )

--- a/scripts/travis-install-cmake.sh
+++ b/scripts/travis-install-cmake.sh
@@ -5,7 +5,7 @@ set -ex
 
 home=$(pwd)
 
-wget https://cmake.org/files/v3.0/cmake-3.0.2.tar.gz
+wget https://cmake.org/files/v3.0/cmake-3.0.2.tar.gz --no-check-certificate
 tar xzf cmake-3.0.2.tar.gz
 rm cmake-3.0.2.tar.gz
 cd cmake-3.0.2

--- a/scripts/travis-install-cmake.sh
+++ b/scripts/travis-install-cmake.sh
@@ -3,6 +3,11 @@
 
 set -ex
 
-wget https://github.com/Viq111/travis-container-packets/releases/download/cmake-3.1.2/cmake.tar.bz2
-tar xjf cmake.tar.bz2
-rm cmake.tar.bz2
+home=$(pwd)
+
+wget https://cmake.org/files/v3.0/cmake-3.0.2.tar.gz
+tar xzf cmake-3.0.2.tar.gz
+rm cmake-3.0.2.tar.gz
+cd cmake-3.0.2
+./bootstrap
+make


### PR DESCRIPTION
Downgrade cmake in our CMakeLists, and install cmake 3.0.2 on travis to catch any regressions. Don't upgrade appveyor b/c f dat.

Closes #32.