### PR TITLE
Throw an `fgt_error` if n choose k overflows

### DIFF
--- a/src/ifgt.cpp
+++ b/src/ifgt.cpp
@@ -30,17 +30,25 @@ namespace {
 const size_t TRUNCATION_NUMBER_UL = 200;
 
 Matrix::Index nchoosek(Matrix::Index n, Matrix::Index k) {
+    auto k_orig = k;
     Matrix::Index n_k = n - k;
     if (k < n_k) {
         k = n_k;
         n_k = n - k;
     }
-    Matrix::Index nchsk = 1;
+    double nchsk = 1;
     for (Matrix::Index i = 1; i <= n_k; ++i) {
         nchsk *= ++k;
         nchsk /= i;
     }
-    return nchsk;
+    if (nchsk > std::numeric_limits<Matrix::Index>::max()) {
+        std::stringstream ss;
+        ss << "n choose k for " << n << " and " << k_orig
+           << " caused an overflow. Dimensionality of the data might be "
+              "too high.";
+        throw fgt_error(ss.str());
+    }
+    return Matrix::Index(nchsk);
 }
 }
 

--- a/test/ifgt_test.cpp
+++ b/test/ifgt_test.cpp
@@ -50,4 +50,9 @@ TEST(Ifgt, UTM) {
     auto target = source;
     ASSERT_THROW(ifgt(source, target, 100, 1e-4), ifgt_no_clusters);
 }
+
+TEST(Ifgt, ManyDimensionsManyPoints) {
+    Matrix source = Matrix::Random(10, 60);
+    ASSERT_THROW(Ifgt(source, 0.4, 1e-4), fgt_error);
+}
 }


### PR DESCRIPTION
It was overflowing silently, which would lead to memory problems quickly
and with no mercy.

Fixes #34.