### PR TITLE
Use BUILD_INTERFACE for EIGEN_INCLUDE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.8.12)
-set(PROJECT_VERSION 0.4.8)
+set(PROJECT_VERSION 0.4.9)
 set(PROJECT_SOVERSION 0)
 
 if(POLICY CMP0048)
@@ -62,10 +62,10 @@ add_library(Library-C++
     ${cluster_src}
     ${PROJECT_BINARY_DIR}/version.cpp
     )
-target_include_directories(Library-C++
-    PUBLIC ${EIGEN3_INCLUDE_DIR}
-    INTERFACE $<INSTALL_INTERFACE:include>
-    PRIVATE include ${NANOFLANN_SOURCE_DIR}/include
+target_include_directories(Library-C++ INTERFACE
+    "$<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>"
+    "$<INSTALL_INTERFACE:include>"
+    PRIVATE include ${NANOFLANN_SOURCE_DIR}/include ${EIGEN3_INCLUDE_DIR}
     )
 set_target_properties(Library-C++ PROPERTIES
     OUTPUT_NAME fgt

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,6 +6,7 @@ function(fgt_test target)
         ${PROJECT_SOURCE_DIR}/include
         ${PROJECT_SOURCE_DIR}/src
         ${PROJECT_BINARY_DIR}
+        ${EIGEN3_INCLUDE_DIR}
         )
     target_link_libraries(${target}
         PRIVATE


### PR DESCRIPTION
We need to roll one more release to update the Fgt-config.cmake to use BUILD_INTERFACE so we don't inject local build paths into the config. This is needed for the @conda-forge package. 

When it succeeds, please snap a new release and we should be done.