### PR TITLE
CMake and added functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW) # Quotes variables in IF statments
 endif()
 
-if${CMAKE_VERSION} VERSION_LESS "3.1.0")
+if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
   find_package(Eigen3 3.1 REQUIRED)
 else()
   find_package (Eigen3 3.1 REQUIRED NO_MODULE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ message(STATUS "[fgt] Version: ${PROJECT_VERSION}")
 option(WITH_BENCH "Build benchmark executable" OFF)
 option(WITH_OPENMP "Use OpenMP parallelization" OFF)
 option(WITH_TESTS "Build test suite" ON)
+option(WITH_EIGEN_NOMODULE "Find Eigen3 with NO_MODULE" OFF)
 
 if(NOT "${BUILD_SHARED_LIBS}" AND "${WITH_OPENMP}")
     message(FATAL_ERROR "Static builds with OpenMP disallowed because they don't propagate well to downstreams. Either set WITH_OPENMP=OFF or build shared.")
@@ -37,11 +38,11 @@ if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW) # Quotes variables in IF statments
 endif()
 
-if(${CMAKE_VERSION} VERSION_LESS "3.1.0")
-  find_package(Eigen3 3.1 REQUIRED)
-else()
-  find_package (Eigen3 3.1 REQUIRED NO_MODULE)
+if(WITH_EIGEN_NOMODULE)
+  find_package(Eigen3 3.1 REQUIRED NO_MODULE)
   link_libraries(Eigen3::Eigen)
+else()
+  find_package(Eigen3 3.1 REQUIRED)
 endif()
 message(STATUS "[fgt] Eigen3 version: ${EIGEN3_VERSION}")
 
@@ -80,6 +81,9 @@ else()
         ${PROJECT_BINARY_DIR}/version.cpp
         )
 endif()
+
+add_library(Fgt::Lib ALIAS Library-C++) # to match exported target
+
 target_include_directories(Library-C++ INTERFACE
     "$<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>"
     "$<INSTALL_INTERFACE:include>"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,12 @@ if(POLICY CMP0054)
     cmake_policy(SET CMP0054 NEW) # Quotes variables in IF statments
 endif()
 
-find_package(Eigen3 3.1 REQUIRED)
+if${CMAKE_VERSION} VERSION_LESS "3.1.0")
+  find_package(Eigen3 3.1 REQUIRED)
+else()
+  find_package (Eigen3 3.1 REQUIRED NO_MODULE)
+  link_libraries(Eigen3::Eigen)
+endif()
 message(STATUS "[fgt] Eigen3 version: ${EIGEN3_VERSION}")
 
 set(GTEST_SOURCE_DIR ${PROJECT_SOURCE_DIR}/vendor/googletest-release-1.10.0)

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -15,6 +15,8 @@
 # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
 # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
 
+if${CMAKE_VERSION} VERSION_LESS "3.1.0")
+
 if(NOT Eigen3_FIND_VERSION)
   if(NOT Eigen3_FIND_VERSION_MAJOR)
     set(Eigen3_FIND_VERSION_MAJOR 2)
@@ -79,3 +81,4 @@ else (EIGEN3_INCLUDE_DIR)
 
 endif(EIGEN3_INCLUDE_DIR)
 
+endif()

--- a/cmake/FindEigen3.cmake
+++ b/cmake/FindEigen3.cmake
@@ -15,8 +15,6 @@
 # Copyright (c) 2009 Benoit Jacob <jacob.benoit.1@gmail.com>
 # Redistribution and use is allowed according to the terms of the 2-clause BSD license.
 
-if${CMAKE_VERSION} VERSION_LESS "3.1.0")
-
 if(NOT Eigen3_FIND_VERSION)
   if(NOT Eigen3_FIND_VERSION_MAJOR)
     set(Eigen3_FIND_VERSION_MAJOR 2)
@@ -80,5 +78,3 @@ else (EIGEN3_INCLUDE_DIR)
   mark_as_advanced(EIGEN3_INCLUDE_DIR)
 
 endif(EIGEN3_INCLUDE_DIR)
-
-endif()

--- a/include/fgt.hpp
+++ b/include/fgt.hpp
@@ -106,6 +106,13 @@ Vector ifgt(const MatrixRef source, const MatrixRef target, double bandwidth,
 Vector ifgt(const MatrixRef source, const MatrixRef target, double bandwidth,
             double epsilon, const VectorRef weights);
 
+/// Computes the direct Gauss transform matrix.
+Matrix mat_direct(const MatrixRef source, const MatrixRef target, double bandwidth);
+
+/// Computes the direct Gauss transform matrix using a kd-tree.
+Matrix mat_direct_tree(const MatrixRef source, const MatrixRef target,
+                   double bandwidth, double epsilon);
+
 /// Abstract base class for all supported variants of the Gauss transform.
 ///
 /// Some flavors of transform can pre-compute some data, e.g. the `DirectTree`

--- a/include/fgt.hpp
+++ b/include/fgt.hpp
@@ -136,10 +136,13 @@ public:
     Vector compute(const MatrixRef target);
     /// Computes the Gauss transform with the given weights.
     Vector compute(const MatrixRef target, const VectorRef weights);
+    /// Computes the Gauss transform without weights essentially returning a matrix.
+    Matrix matrix_compute(const MatrixRef target);
 
 private:
     virtual Vector compute_impl(const MatrixRef target,
                                 const VectorRef weights) const = 0;
+    virtual Matrix matrix_compute_impl(const MatrixRef target) const = 0;
 
     const Matrix m_source;
     double m_bandwidth;
@@ -161,6 +164,7 @@ public:
 private:
     virtual Vector compute_impl(const MatrixRef target,
                                 const VectorRef weights) const;
+    virtual Matrix matrix_compute_impl(const MatrixRef target) const;
 };
 
 /// Direct Gauss transform using a KD-tree truncation.
@@ -192,6 +196,7 @@ private:
 
     virtual Vector compute_impl(const MatrixRef target,
                                 const VectorRef weights) const;
+    virtual Matrix matrix_compute_impl(const MatrixRef target) const;
 
     double m_epsilon;
     std::unique_ptr<NanoflannTree> m_tree;
@@ -233,6 +238,7 @@ public:
 private:
     virtual Vector compute_impl(const MatrixRef target,
                                 const VectorRef weights) const;
+    virtual Matrix matrix_compute_impl(const MatrixRef target) const;
     Vector compute_monomials(const VectorRef d) const;
     Vector compute_constant_series() const;
 

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -69,4 +69,8 @@ Vector direct(const MatrixRef source, const MatrixRef target, double bandwidth,
               const VectorRef weights) {
     return Direct(source, bandwidth).compute(target, weights);
 }
+
+Matrix mat_direct(const MatrixRef source, const MatrixRef target, double bandwidth) {
+  return Direct(source, bandwidth).matrix_compute(target);
+}
 }

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -49,13 +49,17 @@ Matrix Direct::matrix_compute_impl(const MatrixRef target) const {
     auto rows_source = source.rows();
     auto rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
+    Vector v = Vector::Zero(rows_source);
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
+        v.setZero();
         for (Matrix::Index i = 0; i < rows_source; ++i) {
             double distance =
                 (source.row(i) - target.row(j)).array().pow(2).sum();
-            g(j, i) = std::exp(-distance / h2);
+            // g(j, i) = std::exp(-distance / h2);
+            v[i] = std::exp(-distance / h2);
         }
+        g.row(j) = v;
     }
     return g;
 }

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -49,18 +49,13 @@ Matrix Direct::matrix_compute_impl(const MatrixRef target) const {
     auto rows_source = source.rows();
     auto rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
-    // Vector v = Vector::Zero(rows_source);
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
-        // v.setZero();
-        Vector v = g.row(j);
         for (Matrix::Index i = 0; i < rows_source; ++i) {
             double distance =
                 (source.row(i) - target.row(j)).array().pow(2).sum();
-            // g(j, i) = std::exp(-distance / h2);
-            v[i] = std::exp(-distance / h2);
+            g(j, i) = std::exp(-distance / h2);
         }
-        // g.row(j) = v;
     }
     return g;
 }

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -49,17 +49,18 @@ Matrix Direct::matrix_compute_impl(const MatrixRef target) const {
     auto rows_source = source.rows();
     auto rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
-    Vector v = Vector::Zero(rows_source);
+    // Vector v = Vector::Zero(rows_source);
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
-        v.setZero();
+        // v.setZero();
+        Vector v = g.row(j);
         for (Matrix::Index i = 0; i < rows_source; ++i) {
             double distance =
                 (source.row(i) - target.row(j)).array().pow(2).sum();
             // g(j, i) = std::exp(-distance / h2);
             v[i] = std::exp(-distance / h2);
         }
-        g.row(j) = v;
+        // g.row(j) = v;
     }
     return g;
 }

--- a/src/direct.cpp
+++ b/src/direct.cpp
@@ -43,6 +43,23 @@ Vector Direct::compute_impl(const MatrixRef target,
     return g;
 }
 
+Matrix Direct::matrix_compute_impl(const MatrixRef target) const {
+    double h2 = bandwidth() * bandwidth();
+    MatrixRef source = this->source();
+    auto rows_source = source.rows();
+    auto rows_target = target.rows();
+    Matrix g = Matrix::Zero(rows_target, rows_source);
+#pragma omp parallel for
+    for (Matrix::Index j = 0; j < rows_target; ++j) {
+        for (Matrix::Index i = 0; i < rows_source; ++i) {
+            double distance =
+                (source.row(i) - target.row(j)).array().pow(2).sum();
+            g(j, i) = std::exp(-distance / h2);
+        }
+    }
+    return g;
+}
+
 Vector direct(const MatrixRef source, const MatrixRef target,
               double bandwidth) {
     return Direct(source, bandwidth).compute(target);

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -135,7 +135,6 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
     Matrix::Index rows_source = this->source().rows();
     Matrix::Index rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
-    // Vector v = Vector::Zero(rows_source);
     Matrix::Index cols = this->source().cols();
 
     nanoflann::SearchParams params;
@@ -143,18 +142,14 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
 
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
-        // v.setZero();
-        Vector v = g.row(j);
         std::vector<std::pair<size_t, double>> indices_distances;
         indices_distances.reserve(unsigned(rows_source));
         size_t nfound = m_tree->tree.radiusSearch(&target.data()[j * cols], r2,
                                                   indices_distances, params);
         for (size_t i = 0; i < nfound; ++i) {
             auto entry = indices_distances[i];
-            // g(j, entry.first) = std::exp(-entry.second / h2);
-            v[signed(entry.first)] = std::exp(-entry.second / h2);
+            g(j, entry.first) = std::exp(-entry.second / h2);
         }
-        // g.row(j) = v;
     }
     return g;
 }

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -135,6 +135,7 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
     Matrix::Index rows_source = this->source().rows();
     Matrix::Index rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
+    Vector v = Vector::Zero(rows_source);
     Matrix::Index cols = this->source().cols();
 
     nanoflann::SearchParams params;
@@ -142,14 +143,17 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
 
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
+        v.setZero();
         std::vector<std::pair<size_t, double>> indices_distances;
         indices_distances.reserve(unsigned(rows_source));
         size_t nfound = m_tree->tree.radiusSearch(&target.data()[j * cols], r2,
                                                   indices_distances, params);
         for (size_t i = 0; i < nfound; ++i) {
             auto entry = indices_distances[i];
-            g(j, entry.first) = std::exp(-entry.second / h2);
+            // g(j, entry.first) = std::exp(-entry.second / h2);
+            v[signed(entry.first)] = std::exp(-entry.second / h2);
         }
+        g.row(j) = v;
     }
     return g;
 }

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -72,7 +72,7 @@ Vector direct_tree(const MatrixRef source, const MatrixRef target,
 
 Matrix mat_direct_tree(const MatrixRef source, const MatrixRef target,
                    double bandwidth, double epsilon) {
-    return DirectTree(source, bandwidth, epsilon).compute(target);
+    return DirectTree(source, bandwidth, epsilon).matrix_compute(target);
 }
 
 struct DirectTree::NanoflannTree {

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -70,6 +70,11 @@ Vector direct_tree(const MatrixRef source, const MatrixRef target,
     return DirectTree(source, bandwidth, epsilon).compute(target, weights);
 }
 
+Matrix mat_direct_tree(const MatrixRef source, const MatrixRef target,
+                   double bandwidth, double epsilon) {
+    return DirectTree(source, bandwidth, epsilon).compute(target);
+}
+
 struct DirectTree::NanoflannTree {
     typedef nanoflann::KDTreeSingleIndexAdaptor<
         nanoflann::L2_Simple_Adaptor<double, MatrixAdaptor>, MatrixAdaptor>

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -134,7 +134,7 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
     double r2 = cutoff_radius * cutoff_radius;
     Matrix::Index rows_source = this->source().rows();
     Matrix::Index rows_target = target.rows();
-    Matrix g = Vector::Zero(rows_target, rows_source);
+    Matrix g = Matrix::Zero(rows_target, rows_source);
     Matrix::Index cols = this->source().cols();
 
     nanoflann::SearchParams params;

--- a/src/direct_tree.cpp
+++ b/src/direct_tree.cpp
@@ -135,7 +135,7 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
     Matrix::Index rows_source = this->source().rows();
     Matrix::Index rows_target = target.rows();
     Matrix g = Matrix::Zero(rows_target, rows_source);
-    Vector v = Vector::Zero(rows_source);
+    // Vector v = Vector::Zero(rows_source);
     Matrix::Index cols = this->source().cols();
 
     nanoflann::SearchParams params;
@@ -143,7 +143,8 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
 
 #pragma omp parallel for
     for (Matrix::Index j = 0; j < rows_target; ++j) {
-        v.setZero();
+        // v.setZero();
+        Vector v = g.row(j);
         std::vector<std::pair<size_t, double>> indices_distances;
         indices_distances.reserve(unsigned(rows_source));
         size_t nfound = m_tree->tree.radiusSearch(&target.data()[j * cols], r2,
@@ -153,7 +154,7 @@ Matrix DirectTree::matrix_compute_impl(const MatrixRef target) const {
             // g(j, entry.first) = std::exp(-entry.second / h2);
             v[signed(entry.first)] = std::exp(-entry.second / h2);
         }
-        g.row(j) = v;
+        // g.row(j) = v;
     }
     return g;
 }

--- a/src/ifgt.cpp
+++ b/src/ifgt.cpp
@@ -255,4 +255,8 @@ Vector Ifgt::compute_impl(const MatrixRef target,
 
     return G;
 }
+
+Matrix Ifgt::matrix_compute_impl(const MatrixRef target) const {
+  throw fgt_error("Function not yet implemented.");
+}
 }

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -30,4 +30,8 @@ Vector Transform::compute(const MatrixRef target) {
 Vector Transform::compute(const MatrixRef target, const VectorRef weights) {
     return compute_impl(target, weights);
 }
+
+Matrix Transform::matrix_compute(const MatrixRef target) {
+  return matrix_compute_impl(target);
+}
 }


### PR DESCRIPTION
Hi,
I've used fgt to create [pyfgt](https://github.com/hochshi/pyfgt) a simple pybind11 python wrapper around fgt.

Unfortunately, the local FindEigen3.cmake is unable to find Eigen3 when used when through pip or conda build systems. So, I've added an option (WITH_EIGEN_NOMODULE) that allows users to use `find_package(Eigen3 3.1 REQUIRED NO_MODULE)` and link against Eigen3 instead of `find_package(Eigen3 3.1 REQUIRED)`. I haven't messed about with FindEigen3.cmake since I'm unaware of the reasons for it's creation and proper usage.

The second addition has to do with easier usage in Coherent Point Drift, where having the entire matrix instead of weighted sums is considerably faster and easier.
